### PR TITLE
Add goqu support

### DIFF
--- a/src/completion.ts
+++ b/src/completion.ts
@@ -12,8 +12,9 @@ import { generateValidateCompletion } from './tags/validate';
 import { generateMapstructureCompletion } from './tags/mapstructure';
 import { generateRedisCompletion } from './tags/redis';
 import { generateCustomTagCompletion } from './tags/custom';
+import { generateGoquCompletion } from './tags/goqu';
 
-const defaultSupportedTags = ['json', 'bson', 'xorm', 'gorm', 'form', 'yaml', 'binding', 'env', 'envDefault', 'envExpand', 'envPrefix', 'validate', 'mapstructure', 'redis'];
+const defaultSupportedTags = ['json', 'bson', 'xorm', 'gorm', 'form', 'yaml', 'binding', 'env', 'envDefault', 'envExpand', 'envPrefix', 'validate', 'mapstructure', 'redis', 'goqu'];
 var supportedTags: string[] = Object.assign([], defaultSupportedTags);
 
 const structFieldsRegex = /^\s*([a-zA-Z_][a-zA-Z_\d]*)\s+(.+)`(.+)`/;
@@ -155,6 +156,12 @@ export function generateCompletion(lineText: string, position: vscode.Position):
                 break;
             case 'redis':
                 items.push(...generateRedisCompletion(names, ls));
+                break;
+            case 'goqu':
+                if (lineText.includes('db:"-"')) {
+                    break;
+                }
+                items.push(...generateGoquCompletion(names, ls));
                 break;
         }
     }

--- a/src/tags/goqu.ts
+++ b/src/tags/goqu.ts
@@ -1,0 +1,36 @@
+import * as vscode from 'vscode';
+import { LineStruct } from '../completion';
+import { generateCompletionItem, generateFlagCompletionItems, CompletionItems } from './util';
+
+const goquItems = [
+  (name: string) => `goqu:"${name}"`,
+  (name: string) => `goqu:"${name},skipinsert"`,
+  (name: string) => `goqu:"${name},skipupdate"`,
+  (name: string) => `goqu:"${name},defaultifempty"`,
+  (name: string) => `goqu:"${name},omitnil"`,
+  (name: string) => `goqu:"${name},omitempty"`,
+];
+
+const tagDelimiter: string = ",";
+const tagFlags: string[] = ["skipinsert", "skipupdate", "defaultifempty", "omitnil", "omitempty"];
+
+export function generateGoquCompletion(names: string[], ls: LineStruct): vscode.CompletionItem[] {
+  let items = new CompletionItems;
+
+  if (ls.exactTagType) {
+    items.pushAll(generateFlagCompletionItems(ls.leftContent, tagDelimiter, tagFlags));
+    if (items.items.length > 0) {
+      return items.items;
+    }
+  }
+
+  for (let name of names) {
+    for (let f of goquItems) {
+      items.push(generateCompletionItem(f(name), ls));
+    }
+  }
+
+  items.push(generateCompletionItem('goqu:"-"', ls));
+
+  return items.items;
+}


### PR DESCRIPTION
[Goqu](https://github.com/doug-martin/goqu) is a golang query builder to build raw SQL queries in the Go style, with this, we have completion for goqu flags, if the line has `db:"-"` the completion wont work because goqu will omit that field always